### PR TITLE
feat: make without arguments should be able to build a default target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,22 @@
 SHELL := /bin/bash
 SCRIPTS_PATH      := scripts
 
+ifndef IMAGE_NAME
+override IMAGE_NAME = labs-air-edgex
+endif
+ifndef IMAGE_TAG
+override IMAGE_TAG = latest
+endif
+ifndef ECR_REGISTRY
+override ECR_REGISTRY = public.ecr.aws
+endif
+ifndef ECR_REPO_NAME
+override ECR_REPO_NAME = tibcolabs
+endif
+ifndef IMAGE_URL
+override IMAGE_URL = "$(ECR_REGISTRY)/$(ECR_REPO_NAME)"
+endif
+
 .PHONY: build-installer
 build-installer:
 	@$(SCRIPTS_PATH)/build_installer.sh


### PR DESCRIPTION
# Story

It should be possible to type `make` and have a default target build and succeed. It does not matter what the target is, so long as it is reasonable and provides a meaningful output for use with the project.

Help is requested from the reviewer(s) to ensure that the right target is built and the right default values are provided.

## Changes

1. Added some default values to use when none are present.

## Tests

`make` by itself succeeds, but it does not produce a meaningful output. 
