### PR TITLE
Updated linux scripts

### DIFF
--- a/scripts/linux/basicdemo/start.sh
+++ b/scripts/linux/basicdemo/start.sh
@@ -44,9 +44,10 @@ install_cors_plugin () {
     --data "config.max_age=3600"
 }
 
-docker-compose -f ${COMPOSE_FILE} up
+docker-compose -p edgex -f ${COMPOSE_FILE} up -d
 
-install_cors_plugin
+# Only needed when edgex is running with security enabled
+# install_cors_plugin
 
 
 echo $'\n'

--- a/scripts/linux/basicdemo/stop.sh
+++ b/scripts/linux/basicdemo/stop.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker-compose down -v
+docker-compose -p edgex down -v


### PR DESCRIPTION
# Story

Updated linux start and stop scripts

## Changes

1. Updated start script to use -p option and commented out the installation of the cors plugin as Kong is not available when edgex is deployed in non-secure mode
2. Updated stop script to use the -p option.

## Tests

Started and stopped in local environment
