### PR TITLE
Add support for Object data type

### DIFF
--- a/device-generic-mqtt/cmd/res/profiles/Generic-MQTT-Device.yaml
+++ b/device-generic-mqtt/cmd/res/profiles/Generic-MQTT-Device.yaml
@@ -17,12 +17,20 @@ deviceResources:
     mediaType: "image/jpeg"
 
 -
-  name: "str_reading"
+  name: "object_reading"
   isHidden: true
+  description: "sensor object reading"
+  properties:
+    valueType: "Object"
+    readWrite: "R"
+
+-
+  name: "str_reading"
+  isHidden: false
   description: "sensor string reading"
   properties:
     valueType: "String"
-    readWrite: "R"
+    readWrite: "RW"
 
 -
   name: "bool_reading"
@@ -34,11 +42,11 @@ deviceResources:
 
 -
   name: "int16_reading"
-  isHidden: true
+  isHidden: false
   description: "sensor integer reading"
   properties:
     valueType: "Int16"
-    readWrite: "R"
+    readWrite: "RW"
     minimum: "0"
     maximum: "100"
     defaultValue: "0"
@@ -65,9 +73,15 @@ deviceCommands:
   resourceOperations:
     - { deviceResource: "image_reading" }
 -
-  name: dcStrReading
+  name: dcObjectReading
   readWrite: "R"
   isHidden: true
+  resourceOperations:
+    - { deviceResource: "object_reading" }
+-
+  name: dcStrReading
+  readWrite: "RW"
+  isHidden: false
   resourceOperations:
     - { deviceResource: "str_reading" }
 -
@@ -78,8 +92,8 @@ deviceCommands:
     - { deviceResource: "bool_reading" }
 -
   name: dcInt16Reading
-  readWrite: "R"
-  isHidden: true
+  readWrite: "RW"
+  isHidden: false
   resourceOperations:
     - { deviceResource: "int16_reading" }
 -

--- a/device-generic-mqtt/internal/driver/driver.go
+++ b/device-generic-mqtt/internal/driver/driver.go
@@ -159,6 +159,8 @@ func (d *Driver) handleReadCommandRequest(req sdkModel.CommandRequest, topic str
 }
 
 func (d *Driver) HandleWriteCommands(deviceName string, protocols map[string]models.ProtocolProperties, reqs []sdkModel.CommandRequest, params []*sdkModel.CommandValue) error {
+	d.Logger.Debugf("HandleWriteCommands for Device: %s", deviceName)
+
 	commandTopic, err := fetchCommandTopic(protocols)
 	if err != nil {
 		return errors.NewCommonEdgeXWrapper(err)
@@ -176,6 +178,8 @@ func (d *Driver) HandleWriteCommands(deviceName string, protocols map[string]mod
 }
 
 func (d *Driver) handleWriteCommandRequest(req sdkModel.CommandRequest, topic string, param *sdkModel.CommandValue) errors.EdgeX {
+	d.Logger.Debugf("handleWriteCommandRequest for Topic: %s", topic)
+
 	var err error
 	var qos = byte(0)
 	var retained = false

--- a/device-generic-rest/cmd/res/profiles/Generic-REST-Device.yaml
+++ b/device-generic-rest/cmd/res/profiles/Generic-REST-Device.yaml
@@ -15,6 +15,15 @@ deviceResources:
     readWrite: "R"
     mediaType: "image/jpeg"
 
+deviceResources:
+-
+  name: "object_reading"
+  isHidden: true
+  description: "sensor object reading"
+  properties:
+    valueType: "Object"
+    readWrite: "R"
+
 -
   name: "str_reading"
   isHidden: true
@@ -63,6 +72,12 @@ deviceCommands:
   isHidden: true
   resourceOperations:
     - { deviceResource: "image_reading" }
+-
+  name: dcObjectReading
+  readWrite: "R"
+  isHidden: true
+  resourceOperations:
+    - { deviceResource: "object_reading" }
 -
   name: dcStrReading
   readWrite: "R"


### PR DESCRIPTION
# Story

Add support for Edgex new Object data type

## Changes

1. Updated MQTT Generic adapter to provide a resource of Object data type
2. Updated REST Generic adapter to provide a resource of Object data type

## Tests

Local
