### PR TITLE
Changed device name to match STM device

### DIFF
--- a/device-esp32-mqtt/cmd/res/devices/device.MQTT.toml
+++ b/device-esp32-mqtt/cmd/res/devices/device.MQTT.toml
@@ -1,5 +1,5 @@
 [[DeviceList]]
-  Name = "ESP32Device"
+  Name = "kiravtrpi007"
   ProfileName = "ESP32-MQTT-Device"
   Description = "ESP32 MQTT Device"
   Labels = [ "MQTT" ]


### PR DESCRIPTION
# Story

Changed device name to match STM device

## Changes

1. Update device profile to match STM device name

## Tests

Local
