### PR TITLE
Changed data type for joint1_control resource from Bool to String

### DIFF
--- a/device-jetmax-mqtt/cmd/res/profiles/Jetmax-Robot-Arm.yaml
+++ b/device-jetmax-mqtt/cmd/res/profiles/Jetmax-Robot-Arm.yaml
@@ -68,7 +68,7 @@ deviceResources:
   isHidden: true
   description: "Joint 1 control"
   properties:
-    valueType: "Bool"
+    valueType: "String"
     readWrite: "RW"
 
 -

--- a/device-jetmax-mqtt/internal/driver/driver.go
+++ b/device-jetmax-mqtt/internal/driver/driver.go
@@ -213,6 +213,8 @@ func (d *Driver) handleWriteCommandRequest(req sdkModel.CommandRequest, topic st
 	switch req.Type {
 	case common.ValueTypeBool:
 		data["data"] = commandValue
+	case common.ValueTypeString:
+		data["data"] = commandValue
 	default:
 		data["data"] = commandValue
 		data["duration"] = 1


### PR DESCRIPTION
Changed driver to handle string resources

# Story

Changed data type for joint1_control resource from Bool to String

## Changes

1. Updated device profile
2. Updated driver to handle string resource

## Tests

Local
