### PR TITLE
Updated windows scripts

### DIFF
--- a/installers/community/start-edge.cmd
+++ b/installers/community/start-edge.cmd
@@ -2,8 +2,10 @@
 
 echo %1
 
-if "%1%"==""  set ARCH=""
-if "%1%"=="amd64"  set ARCH=""
+set ARCH=
+
+if "%1%"==""  set ARCH=
+if "%1%"=="amd64"  set ARCH=
 
 set EDGE_TYPE=%2
 if "%2%"==""  set EDGE_TYPE="generic"

--- a/installers/community/stop-edge.cmd
+++ b/installers/community/stop-edge.cmd
@@ -1,8 +1,10 @@
 @echo off
 
-if "%1%"==""  set ARCH=""
-if "%1%"=="amd64"  set ARCH=""
-if "%1%"=="arm64"  set ARCH="-arm64"
+set ARCH=
+
+if "%1%"==""  set ARCH=
+if "%1%"=="amd64"  set ARCH=
+
 
 set EDGE_TYPE=%2
 if "%2%"==""  set EDGE_TYPE="generic"


### PR DESCRIPTION

# Story

Updated windows scripts to use empty string instead of empty double quotes

## Changes

1. Updated start-edge.cmd
2. Updated stop-edge.cmd

## Tests

NA
