### PR TITLE
Updated scripts to fix reference to environment variables

### DIFF
--- a/installers/community/start-edge.cmd
+++ b/installers/community/start-edge.cmd
@@ -13,7 +13,7 @@ if "%2%"==""  set EDGE_TYPE="generic"
 echo  " Starting Edge: %EDGE_TYPE%"
 
 
-docker-compose -p edgex -f docker-compose-edgex-no-secty.yml  -f docker-compose-air-no-secty.yml -f docker-compose-air-no-secty-demo-%EDGE_TYPE%.yml up
+docker-compose -p edgex -f docker-compose-edgex-no-secty.yml  -f docker-compose-air-no-secty.yml -f docker-compose-air-no-secty-demo-%EDGE_TYPE%.yml up -d
 
 
 echo "\n"

--- a/scripts/start.cmd
+++ b/scripts/start.cmd
@@ -7,5 +7,5 @@ set ARCH=""
 set EDGE_TYPE="generic"
 
 
-call start-edge.cmd $ARCH $EDGE_TYPE
+call start-edge.cmd %ARCH% %EDGE_TYPE%
 

--- a/scripts/stop.cmd
+++ b/scripts/stop.cmd
@@ -4,4 +4,4 @@ set ARCH=""
 
 set EDGE_TYPE="generic"
 
-call stop-edge.cmd $ARCH $EDGE_TYPE
+call stop-edge.cmd %ARCH% %EDGE_TYPE%


### PR DESCRIPTION
# Story

Updated scripts to fix reference to environment variables

## Changes

1. Updated start.cmd and stop.cmd scripts to use % instead of $ to refer to environment variables
2. Updated script to use -d flag on docker-compose command

## Tests

NA
